### PR TITLE
Fix failing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>Chelsea.BUILD-SNAPSHOT</version>
+                <version>Chelsea.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-build</artifactId>
-        <version>1.2.2.BUILD-SNAPSHOT</version>
+        <version>2.0.2.RELEASE</version>
     </parent>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>Chelsea.RELEASE</version>
+                <version>Elmhurst.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>Chelsea.RELEASE</version>
+                <version>Chelsea.BUILD-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-stream-binder-jms-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0</version>
+    <version>1.0.0.BUILD-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-stream-binder-jms-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <parent>
         <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-stream-binder-jms-activemq-test-support/pom.xml
+++ b/spring-cloud-stream-binder-jms-activemq-test-support/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>spring-cloud-stream-binder-jms-activemq-test-support</artifactId>
 
     <properties>
-        <activemq.version>5.14.0</activemq.version>
+        <activemq.version>5.15.4</activemq.version>
     </properties>
 
     <dependencies>

--- a/spring-cloud-stream-binder-jms-activemq/pom.xml
+++ b/spring-cloud-stream-binder-jms-activemq/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
-            <version>5.14.0</version>
+            <version>5.15.4</version>
         </dependency>
 
         <!--Test dependencies-->

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/receiver/ReceiverApplication.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/receiver/ReceiverApplication.java
@@ -23,15 +23,15 @@ import java.util.concurrent.CountDownLatch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
-@SpringBootApplication(exclude = {EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class, JmxAutoConfiguration.class})
+@SpringBootApplication(exclude = {ServletWebServerFactoryAutoConfiguration.class, WebMvcAutoConfiguration.class, JmxAutoConfiguration.class})
 @EnableBinding(Sink.class)
 public class ReceiverApplication {
 

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/sender/SenderApplication.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/sender/SenderApplication.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -31,7 +31,7 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
-@SpringBootApplication(exclude = {EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class})
+@SpringBootApplication(exclude = {EmbeddedWebServerFactoryCustomizerAutoConfiguration.class, WebMvcAutoConfiguration.class})
 @EnableBinding(Source.class)
 public class SenderApplication {
 

--- a/spring-cloud-stream-binder-jms-common/pom.xml
+++ b/spring-cloud-stream-binder-jms-common/pom.xml
@@ -34,11 +34,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-java-dsl</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jms_1.1_spec</artifactId>
             <version>1.0</version>

--- a/spring-cloud-stream-binder-jms-common/pom.xml
+++ b/spring-cloud-stream-binder-jms-common/pom.xml
@@ -23,14 +23,15 @@
             <artifactId>spring-cloud-stream</artifactId>
         </dependency>
 
+        <!--<dependency>-->
+            <!--<groupId>org.springframework.integration</groupId>-->
+            <!--<artifactId>spring-integration-jms</artifactId>-->
+        <!--</dependency>-->
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-jms</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-codec</artifactId>
+            <version>5.0.6.RELEASE</version>
         </dependency>
 
         <dependency>

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
@@ -83,7 +83,7 @@ public class JMSMessageChannelBinder
 
 	@Override
 	protected MessageHandler createProducerMessageHandler(ProducerDestination producerDestination,
-			ExtendedProducerProperties<JmsProducerProperties> producerProperties) throws Exception {
+			ExtendedProducerProperties<JmsProducerProperties> producerProperties, MessageChannel errorChannel) throws Exception {
 		TopicPartitionRegistrar topicPartitionRegistrar = new TopicPartitionRegistrar();
 		Session session = connectionFactory.createConnection().createSession(true, 1);
 

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderAutoConfiguration.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.stream.binder.jms.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -33,7 +32,7 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
-@Import({JmsBinderGlobalConfiguration.class, KryoCodecAutoConfiguration.class})
+@Import(JmsBinderGlobalConfiguration.class)
 public class JmsBinderAutoConfiguration {
 
 }

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.cloud.stream.binder.jms.utils.SpecCompliantJmsHeaderM
 import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.integration.codec.Codec;
 import org.springframework.jms.core.JmsTemplate;
 
 /**
@@ -106,13 +105,12 @@ public class JmsBinderGlobalConfiguration {
 		private JmsExtendedBindingProperties jmsExtendedBindingProperties;
 
 		@Bean
-		JMSMessageChannelBinder jmsMessageChannelBinder(Codec codec,
+		JMSMessageChannelBinder jmsMessageChannelBinder(
 				JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory,
 				JmsSendingMessageHandlerFactory jmsSendingMessageHandlerFactory, JmsTemplate jmsTemplate) throws Exception {
 
 			JMSMessageChannelBinder jmsMessageChannelBinder = new JMSMessageChannelBinder(provisioningProvider,
 					jmsSendingMessageHandlerFactory, jmsMessageDrivenChannelAdapterFactory, jmsTemplate, connectionFactory);
-			jmsMessageChannelBinder.setCodec(codec);
 			jmsMessageChannelBinder.setExtendedBindingProperties(jmsExtendedBindingProperties);
 			return jmsMessageChannelBinder;
 		}

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
@@ -30,7 +30,7 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.jms.config.JmsConsumerProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.integration.dsl.jms.JmsMessageDrivenChannelAdapter;
+import org.springframework.integration.jms.JmsMessageDrivenEndpoint;
 import org.springframework.integration.jms.ChannelPublishingJmsMessageListener;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
@@ -73,12 +73,12 @@ public class JmsMessageDrivenChannelAdapterFactory implements ApplicationContext
 		this.applicationContext = applicationContext;
 	}
 
-	public JmsMessageDrivenChannelAdapter build(Queue destination,
+	public JmsMessageDrivenEndpoint build(Queue destination,
 			final ExtendedConsumerProperties<JmsConsumerProperties> properties) {
 		RetryingChannelPublishingJmsMessageListener listener = new RetryingChannelPublishingJmsMessageListener(
 				properties, messageRecoverer, properties.getExtension().getDlqName());
 		listener.setBeanFactory(this.beanFactory);
-		JmsMessageDrivenChannelAdapter adapter = new JmsMessageDrivenChannelAdapter(
+		JmsMessageDrivenEndpoint adapter = new JmsMessageDrivenEndpoint(
 				listenerContainerFactory.build(destination), listener);
 		adapter.setApplicationContext(this.applicationContext);
 		adapter.setBeanFactory(this.beanFactory);


### PR DESCRIPTION
Previously, when doing `mvn clean install` there were some tests failing with
```Tests in error: 
 Tests in error: 
  scs_whenRequiredGroupsAreSpecified_messagesArePersistedWithoutConsumers(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenNoConsumerGroups_appsReceiveMessage(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenHeadersAreSpecified_headersArePassedThrough(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenMultipleMembersOfSameConsumerGroup_groupOnlySeesEachMessageOnce(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenConsumerFails_retriesTheSpecifiedAmountOfTimes(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_supportsSerializable(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenMultipleConsumerGroups_eachGroupGetsAllMessages(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenHeadersContainingIllegalCharactersAreSpecified_headersAreRewrittenAndPassedThrough(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_maxAttempts1_preventsRetry(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_supportsPrimitive(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenAPartitioningKeyIsConfigured_messagesAreRoutedToTheRelevantPartition(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenMessageIsSentToDLQ_stackTraceAddedToHeaders(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V
  scs_whenAPartitioningKeyIsConfiguredAsWellAsRequired_messagesArePersistedInTheRelevantPartition(org.springframework.cloud.stream.binder.jms.activemq.integration.EndToEndIntegrationTests): org.springframework.cloud.stream.binding.StreamListenerMessageHandler.setNotPropagatedHeaders([Ljava/lang/String;)V

Tests run: 26, Failures: 0, Errors: 13, Skipped: 0

```
By upgrading the version of **spring-cloud-stream-dependencies**, the project is building successfully now.